### PR TITLE
Fixes vanilla bug/inconsistency in harvester replacement logic 

### DIFF
--- a/REDALERT/HOUSE.CPP
+++ b/REDALERT/HOUSE.CPP
@@ -6417,9 +6417,14 @@ int HouseClass::AI_Unit(void)
 
 	/*
 	**	A computer controlled house will try to build a replacement
-	**	harvester if possible.
+	**	harvester if possible. Never replace harvesters if the game
+	**	is in easy mode.
+	**		CFE Note: Vanilla bugfix - Difficulty was accidentally set check if != DIFF_HARD, when it was supposed to be != DIFF_EASY.
+	**		Was correct in one place but not the other two spots (including this one) with the same harvester build logic. 
+	**		Jump to the others by searching the below phrase:
+	**			CFE Harvester Build Fix
 	*/
-	if (IQ >= Rule.IQHarvester && !IsTiberiumShort && !IsHuman && BQuantity[STRUCT_REFINERY] > UQuantity[UNIT_HARVESTER] && Difficulty != DIFF_HARD) {
+	if (IQ >= Rule.IQHarvester && !IsTiberiumShort && !IsHuman && BQuantity[STRUCT_REFINERY] > UQuantity[UNIT_HARVESTER] && Difficulty != DIFF_EASY) {
 		if (UnitTypeClass::As_Reference(UNIT_HARVESTER).Level <= (unsigned)Control.TechLevel) {
 			BuildUnit = UNIT_HARVESTER;
 			return(TICKS_PER_SECOND);

--- a/TIBERIANDAWN/HOUSE.CPP
+++ b/TIBERIANDAWN/HOUSE.CPP
@@ -3804,8 +3804,8 @@ TechnoTypeClass const * HouseClass::Suggest_New_Object(RTTIType objecttype) cons
 
 				/*
 				**	A computer controlled house will try to build a replacement
-				**	harvester if possible. Never replace harvesters if the game
-				**	is in easy mode.
+				**	harvester if possible. Never replace harvesters if the AI
+				**	is set to easy mode.
 				**		CFE Note: Vanilla bugfix - Difficulty is CORRECTLY set to check !DIFF_EASY here, but not in two other spots that also control the same harvester replacement logic.
 				**		Jump to the others by searching the below phrase:
 				**			CFE Harvester Build Fix
@@ -6905,8 +6905,8 @@ int HouseClass::AI_Unit(void)
 
 	/*
 	**	A computer controlled house will try to build a replacement
-	**	harvester if possible. Never replace harvesters if the game
-	**	is in easy mode.
+	**	harvester if possible. Never replace harvesters if the AI
+	**	is set to easy mode.
 	**		CFE Note: Vanilla bugfix - Difficulty was accidentally set check if != DIFF_HARD, when it was supposed to be != DIFF_EASY.
 	**		Was correct in one place but not the other two spots (including this one) with the same harvester build logic. 
 	**		Jump to the others by searching the below phrase:

--- a/TIBERIANDAWN/HOUSE.CPP
+++ b/TIBERIANDAWN/HOUSE.CPP
@@ -3806,6 +3806,9 @@ TechnoTypeClass const * HouseClass::Suggest_New_Object(RTTIType objecttype) cons
 				**	A computer controlled house will try to build a replacement
 				**	harvester if possible. Never replace harvesters if the game
 				**	is in easy mode.
+				**		CFE Note: Vanilla bugfix - Difficulty is CORRECTLY set to check !DIFF_EASY here, but not in two other spots that also control the same harvester replacement logic.
+				**		Jump to the others by searching the below phrase:
+				**			CFE Harvester Build Fix
 				*/
 				if (!(GameToPlay == GAME_NORMAL && PlayerPtr->Difficulty == DIFF_EASY) && !IsHuman && (ActiveBScan & STRUCTF_REFINERY) && !(UScan & UNITF_HARVESTER)) {
 					techno = &UnitTypeClass::As_Reference(UNIT_HARVESTER);
@@ -6902,9 +6905,14 @@ int HouseClass::AI_Unit(void)
 
 	/*
 	**	A computer controlled house will try to build a replacement
-	**	harvester if possible.
+	**	harvester if possible. Never replace harvesters if the game
+	**	is in easy mode.
+	**		CFE Note: Vanilla bugfix - Difficulty was accidentally set check if != DIFF_HARD, when it was supposed to be != DIFF_EASY.
+	**		Was correct in one place but not the other two spots (including this one) with the same harvester build logic. 
+	**		Jump to the others by searching the below phrase:
+	**			CFE Harvester Build Fix
 	*/
-	if (IQ >= Rule.IQHarvester && !IsTiberiumShort && !IsHuman && BQuantity[STRUCT_REFINERY] > UQuantity[UNIT_HARVESTER] && Difficulty != DIFF_HARD) {
+	if (IQ >= Rule.IQHarvester && !IsTiberiumShort && !IsHuman && BQuantity[STRUCT_REFINERY] > UQuantity[UNIT_HARVESTER] && Difficulty != DIFF_EASY) {
 		//if (UnitTypeClass::As_Reference(UNIT_HARVESTER).Level <= (unsigned)Control.TechLevel) {
 		if (UnitTypeClass::As_Reference(UNIT_HARVESTER).Level <= (unsigned)BuildLevel) {
 			BuildUnit = UNIT_HARVESTER;


### PR DESCRIPTION
Vanilla behavior is SUPPOSED to be that Easy AI are never supposed to replace their harvesters (it's explicitly stated in TD's code for the campaign AI here):
https://github.com/ChthonVII/CnC_Remastered_Collection/blob/a432e30081ea6228b3e4eebf398a9d82fa545d81/TIBERIANDAWN/HOUSE.CPP#L3805-L3810

However, it appears this was accidentally inverted in RA's equivalent build logic - checking if the AI's difficulty is not set to hard, meaning that Hard AI will not replace their harvesters instead. This mistake then got backported to TD for the skirmish AI with the remaster.

This is an obvious inconsistency/mistake resulting in the Hard AI actually being easier to defeat by just targeting their harvesters, and the easy AI being harder than intended. 